### PR TITLE
Fix MONGODB_URI environment variable in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ All of your components, I'd group these up per page as well.
 Folder for everything back-end related. Houses a decoupled, Node API.  
 **Note that this folder should have a `.env` file that includes a `MONGODB_URL` variable.** It should point to your local instance of MongoDB.
 ```
-MONGODB_URL=mongodb://localhost:27017/digital-empowerment
+MONGODB_URI=mongodb://localhost:27017/digital-empowerment
 ```
 
 `server/src/controller`  


### PR DESCRIPTION
The README mentions `MONGODB_URL`, but the server expects `MONGODB_URI`.